### PR TITLE
Add Message to Service Page If There is No Content

### DIFF
--- a/_layouts/service.html
+++ b/_layouts/service.html
@@ -24,3 +24,11 @@ layout: single
     {{ procedure.description | markdownify }}
   {% endfor %}
 {% endif %}
+
+{% unless service_posts.size > 0 %}
+<hr />
+
+<div class="text-center notice--info">
+  Looks like we don't have any posts for this service yet, but check back later for what is sure to be some grade-A content!
+</div>
+{% endunless %}


### PR DESCRIPTION
Sometimes we want to display a service page before we've written any posts for that service yet. Usually this would be when we want to link to a service page from a post when we know that the future service posts will be written soon.

closes #41 