### PR TITLE
Enable giscus Comments

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -37,6 +37,16 @@ breadcrumbs: true
 breadcrumb_home_url: /learn
 breadcrumb_home_label: Learn
 
+comments:
+  provider: "giscus"
+  giscus:
+    repo_id          : "MDEwOlJlcG9zaXRvcnkyNzA2Nzc5MzE="
+    category_name    : "Q&A"
+    category_id      : "DIC_kwDOECI3q84CcORJ"
+    discussion_term  : "og:title"
+    reactions_enabled: 1
+    theme            : "noborder_light"
+
 defaults:
   - scope:
       path: ""


### PR DESCRIPTION
This enables **giscus** comments as configured according to the following resources.

- [Minimal Mistakes theme giscus comments](https://mmistakes.github.io/minimal-mistakes/docs/configuration/#giscus-comments)
- [giscus.app](https://giscus.app/)

resolves #31