### PR TITLE
Fix Comments Provider

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -37,6 +37,9 @@ breadcrumbs: true
 breadcrumb_home_url: /learn
 breadcrumb_home_label: Learn
 
+comments:
+  provider: "giscus"
+
 defaults:
   - scope:
       path: ""

--- a/_config.yml
+++ b/_config.yml
@@ -37,16 +37,6 @@ breadcrumbs: true
 breadcrumb_home_url: /learn
 breadcrumb_home_label: Learn
 
-comments:
-  provider: "giscus"
-  giscus:
-    repo_id          : "MDEwOlJlcG9zaXRvcnkyNzA2Nzc5MzE="
-    category_name    : "Q&A"
-    category_id      : "DIC_kwDOECI3q84CcORJ"
-    discussion_term  : "og:title"
-    reactions_enabled: 1
-    theme            : "noborder_light"
-
 defaults:
   - scope:
       path: ""
@@ -70,6 +60,15 @@ defaults:
       author_profile: true
       toc_icon: cloud
       toc_sticky: true
+      comments:
+        provider: "giscus"
+        giscus:
+          repo_id          : "MDEwOlJlcG9zaXRvcnkyNzA2Nzc5MzE="
+          category_name    : "General"
+          category_id      : "DIC_kwDOECI3q84CcORI"
+          discussion_term  : "og:title"
+          reactions_enabled: 1
+          theme            : "light"
   - scope:
       path: "*/learn/*"
       type: posts


### PR DESCRIPTION
Moving most of the giscus comments configuration to the default Front Matter for posts. I initially thought it all went in *_config.yml*.