### PR TITLE
Add Sitemap

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -81,3 +81,4 @@ defaults:
 plugins:
   - jekyll-include-cache
   - jemoji
+  - jekyll-sitemap


### PR DESCRIPTION
Adds the [jekyll-sitemap](https://github.com/jekyll/jekyll-sitemap) plugin in order to generate a sitemap.

closes #53