### PR TITLE
Increase Notice Box Link/Text Contrast

### DIFF
--- a/_sass/minimal-mistakes-overrides.scss
+++ b/_sass/minimal-mistakes-overrides.scss
@@ -27,3 +27,50 @@
 .toc__menu {
     font-size: 1em;
 }
+
+// Override notice link color because the contrast isn't high enough.
+@mixin notice($notice-color) {
+  a {
+    color: mix(#000, $notice-color, 40%);
+
+    &:hover {
+      color: mix(#000, $notice-color, 85%);
+    }
+  }
+}
+
+/* Default notice */
+
+.notice {
+  @include notice($light-gray);
+}
+  
+  /* Primary notice */
+  
+.notice--primary {
+  @include notice($primary-color);
+}
+
+/* Info notice */
+
+.notice--info {
+  @include notice($info-color);
+}
+
+/* Warning notice */
+
+.notice--warning {
+  @include notice($warning-color);
+}
+
+/* Success notice */
+
+.notice--success {
+  @include notice($success-color);
+}
+
+/* Danger notice */
+
+.notice--danger {
+  @include notice($danger-color);
+}


### PR DESCRIPTION
The contrast between link (anchor) text and the rest of the text in a [notice](https://mmistakes.github.io/minimal-mistakes/docs/utility-classes/#notices) box is not great enough, especially for the greenish color I'm using for the primary color. This decreases the opacity for the link text in notice boxes.

resolves #52 