### PR TITLE
"Get Code" Banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,25 @@ The simplest way to make changes is to set custom values for variables in the [*
 
 The [*minimal-mistakes-overrides.scss*](/_sass/minimal-mistakes-overrides.scss) is imported after the theme SASS is imported. You can specify SASS content that will take precedence over the theme's SASS.
 
+### Get Code Banner
+
+To add a banner at the top of a post to show where a visitor can download the code sample, add the following `repos` Front Matter. For each repo, a link to the GitHub tag page and a `git clone` command will be added. There will also be a link to a post that has more information about downloading the tagged repository.
+
+``` yaml
+repos:
+  - alias: infrastructure_repo
+    tag: web/static-web-app/new-terraform-resource
+  - alias: sample-code
+    tag: sometag
+    github_org: anotherorg
+```
+
+|Property|Required|Description|
+|--------|--------|-----------|
+|`alias`|:heavy_check_mark:|The alias of repository from the [fake.yml](_data/fake.yml) data file. If not found, the value of the alias is used.|
+|`tag`|:heavy_check_mark:|The tag name that defines this |
+|`github_org`||Specify the GitHub organization name if this isn't a 2ndsleep repository.|
+
 ### Render Folder Structure
 
 Use the [*filesystem.html*](/_includes/filesystem.html) include to render a folder structure with file/folder emojis. This include requires the folder structure to defined by Front Matter on the page, as so:
@@ -176,13 +195,13 @@ You can include image attribution using the *attribution.html* include, which su
 
 |Parameter|Required|Description|
 |---------|--------|-----------|
-|title|Yes|Name or title of the image|
-|image_link|No|Link to the image file|
-|quote_title|No|If this is [truthy](https://shopify.github.io/liquid/basics/truthy-and-falsy/), the title is surrounded by quotes|
-|author|Yes|Name of the author|
-|author_link|No|Link to author profile|
-|license|Yes|Name of the image's license|
-|license_link|Yes|Link to license|
+|title|:heavy_check_mark:|Name or title of the image|
+|image_link||Link to the image file|
+|quote_title||If this is [truthy](https://shopify.github.io/liquid/basics/truthy-and-falsy/), the title is surrounded by quotes|
+|author|:heavy_check_mark:|Name of the author|
+|author_link||Link to author profile|
+|license|:heavy_check_mark:|Name of the image's license|
+|license_link|:heavy_check_mark:|Link to license|
 
 This include can be captured to a variable that can then be used to pass to the caption for the image. The *svg.html* include has the `attribution` parameter (see [SVG Drawings](#svg-drawings)). For the [*figure*](https://mmistakes.github.io/minimal-mistakes/docs/helpers/#figure) include, you will need to add the attribution to the `caption` parameter.
 

--- a/_config.yml
+++ b/_config.yml
@@ -64,7 +64,7 @@ defaults:
       path: ""
       type: posts
     values:
-      layout: single
+      layout: secondsleep_single
       page_type: post
       read_time: true
       author_profile: true

--- a/_drafts/learn/web/static-web-app-dns/procedures/2024-03-31-add-custom-domain.md
+++ b/_drafts/learn/web/static-web-app-dns/procedures/2024-03-31-add-custom-domain.md
@@ -3,6 +3,9 @@ title: Add Custom www Domain
 categories: web static-web-app-custom-domain procedure
 sort_order: 6
 description: Let's use a real URL instead of stupid one.
+repos:
+  - alias: infrastructure_repo
+    tag: web/static-web-app/new-terraform-resource
 ---
 {% assign fqdn = 'www.' | append: site.data.fake.company_domain %}
 

--- a/_includes/repo_banner.html
+++ b/_includes/repo_banner.html
@@ -1,0 +1,13 @@
+{% if include.repos.size > 0 %}
+  <p class="notice--success">
+  {% for repo in include.repos %}
+    {% assign repo_url = repo.github_org | default: '2ndsleep' | prepend: 'https://github.com/' %}
+    {% assign repo_name = site.data.fake[repo.alias] | default: repo.alias %}
+    {% if forloop.first %}<i class="fa-brands fa-github"></i> Follow along by getting the code from the {% if forloop.length == 1 %}<strong>{{ repo_name }}</strong> repo{% else %}repos{% endif %}. <a href="{% post_url /thoughts/2024-06-05-copy-repo %}"><small>help</small></a>{% endif %}<br />
+    {% if forloop.length > 1 %}<strong>{{ repo_name }}</strong>{% endif %}<br />
+    <a href="{{ repo_url }}/{{ repo_name }}/releases/tag/{{ repo.tag | url_encode }}" class="btn btn--success">Download</a><br />
+    &nbsp;&nbsp;<em><small>-or-</small></em><br />
+    <code class="language-plaintext highlighter-rouge">git clone {{ repo_url }}/{{ repo_name }} --branch {{ repo.tag }}</code><br />
+  {% endfor %}
+  </p>
+{% endif %}

--- a/_layouts/secondsleep_single.html
+++ b/_layouts/secondsleep_single.html
@@ -1,0 +1,6 @@
+---
+layout: single
+---
+{% include repo_banner.html repos=page.repos %}
+
+{{ content }}


### PR DESCRIPTION
A "Get Code" banner can be added to the top of the post by defining a `repos` dictionary in a posts Front Matter. For each repo, a link to the repository's tag page and a `git clone` command will be added. There is also a link to a helper post that provides more information. See the [README](README.md#get-code-banner) page for usage information.